### PR TITLE
#3 Fix

### DIFF
--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -70,7 +70,7 @@ export class SpotifyParser {
 			}
 		};
 
-		this.renew.bind(this)();
+		this.renew();
 	}
 
 	/**
@@ -136,7 +136,7 @@ export class SpotifyParser {
 	}
 
 	private async renew(): Promise<void> {
-		setTimeout(this.renew, await this.renewToken());
+		setTimeout(this.renew.bind(this), await this.renewToken());
 	}
 
 }

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -70,7 +70,7 @@ export class SpotifyParser {
 			}
 		};
 
-		this.renew();
+		this.renew.bind(this);
 	}
 
 	/**

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -70,7 +70,7 @@ export class SpotifyParser {
 			}
 		};
 
-		this.renew.bind(this);
+		this.renew.bind(this)();
 	}
 
 	/**


### PR DESCRIPTION
This pull request fixes #3.

## Description
This fix binds the `renew` method to the `SpotifyParser` class.

## Motivation and Context
`this` currently refers to the global scope. By binding the renew method to the `SpotifyParser` class, `this` now refers to the class itself.

## How Has This Been Tested?
This fix has not yet been tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
