### PR TITLE
feat: convert to lavalink object on method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ await Promise.all(album.map(async (name) => tracks.push(await spotilink.fetchTra
 // 'tracks' will now contain Lavalink track objects.
 // SpotifyParser#fetchTrack will only return the track object, giving you complete freedom and control on how you handle the Lavalink tracks. :)
 ```
+---
+
+The following methods below, if `true` is passed on the second parameter will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
+```javascript
+// Get a song in the form of a Lavalink object.
+const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
+
+// Get all songs from an album in the form of an array of Lavalink objects.
+const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ', true);
+
+// Get all songs from a playlist in the form of an array of Lavalink objects.
+const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', true);
+
+
+```
 
 ## Contributors ✨
 

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -76,29 +76,51 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the album and return its artists and track name.
 	 * @param id The album ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
-	public async getAlbumTracks(id: string): Promise<string[]> {
+	public async getAlbumTracks(id: string, convert = false): Promise<string[]|LavalinkTrack[]> {
 		const { items }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
-		return items.map(song => `${song.artists.map(artist => artist.name).join(", ")} - ${song.name}`);
+		const tracks = items.map(song => `${song.artists.map(artist => artist.name).join(", ")} - ${song.name}`);
+
+		if (convert) {
+			return Promise.all(tracks.map(async (title) => await this.fetchTrack(title)) as LavalinkTrack[]);
+		}
+
+		return tracks;
+
 	}
 
 	/**
 	 * Fetch the tracks from the playlist and return its artists and track name.
 	 * @param id The playlist ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
-	public async getPlaylistTracks(id: string): Promise<string[]> {
+	public async getPlaylistTracks(id: string, convert = false): Promise<string[]|LavalinkTrack[]> {
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
-		return items.map(item => `${item.track.artists.map(artist => artist.name).join(", ")} - ${item.track.name}`);
+		const tracks: string[] = items.map(item => `${item.track.artists.map(artist => artist.name).join(", ")} - ${item.track.name}`);
+
+		if (convert) {
+			return Promise.all(tracks.map(async (title) => await this.fetchTrack(title)) as LavalinkTrack[]);
+		}
+
+		return tracks;
 	}
 
 	/**
 	 * Fetch the track and return its artist and title
 	 * @param id The song ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of track name.
 	 */
-	public async getTrack(id: string): Promise<string> {
+	public async getTrack(id: string, convert = false): Promise<string|LavalinkTrack> {
 		const track: Track = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 		const artists: string[] = track.artists.map(artist => artist.name);
-		return `${artists.join(", ")} - ${track.name}`;
+		const title = `${artists.join(", ")} - ${track.name}`;
+
+		if (convert) {
+			return this.fetchTrack(title) as LavalinkTrack;
+		}
+
+		return title;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR allows conversion of track titles into Lavalink objects on certain method calls.
## Description
<!--- Describe your changes in detail -->
This PR gives users an optional boolean parameter on `getAlbumTracks`, `getPlaylistTracks` and `getTrack` that calls `fetchTrack` and returns a Lavalink object if true.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allows users to simultaneously convert tracks returned by Spotify API into Lavalink objects, providing efficiency compared to having to call `fetchTrack` yourself and still have the option to opt-out of this feature.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran an instance of this PR in a private server running Node version `14.8.0` and the latest Docker image of Lavalink, all aforementioned methods runs successfully without errors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
