### PR TITLE
Track search priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ const node = {
 const spotilink =  new SpotifyParser(node, spotifyID, spotifySecret);
 
 // Get a song title
-const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // { artists: [ "Surfaces" ], name: "Sunday Best" }
+const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // { track: "", info: { author: "Surfaces", title: "Surfaces - Sunday Best (Official Music Video)" }, ... }
 
 // Get all songs from an album
-const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ { artists: [ "Kygo", "Valerie Broussard" ], name: "The Truth" }, ... ]
+const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ { track: "", info: { ... } }, ... ]
 
 // Get all songs from a playlist
-const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ { arists: [ "Cardi B", "Megan Thee Stallion" ], name: "WAP (feat. Megan Thee Stallion)" }, ... ]
+const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ { track: "", info: { ... } }, ... ]
 
 // Fetch song from the Lavalink API
 const track = await spotilink.fetchTrack(song) // { track: "", info: {} }
@@ -51,19 +51,6 @@ const tracks = [];
 await Promise.all(album.map(async (name) => tracks.push(await spotilink.fetchTrack(name))));
 // 'tracks' will now contain Lavalink track objects.
 // SpotifyParser#fetchTrack will only return the track object, giving you complete freedom and control on how you handle the Lavalink tracks. :)
-```
----
-
-The following methods below, if `true` is passed on the second parameter will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
-```javascript
-// Get a song in the form of a Lavalink object.
-const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
-// Get all songs from an album in the form of an array of Lavalink objects.
-const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ', true);
-// Get all songs from a playlist in the form of an array of Lavalink objects.
-const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', true);
-
-
 ```
 
 ## Contributors ✨

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ const node = {
 const spotilink =  new SpotifyParser(node, spotifyID, spotifySecret);
 
 // Get a song title
-const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // Surfaces - Sunday Best
+const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // { track: "", info: { author: "Surfaces", title: "Surfaces - Sunday Best (Official Music Video)" }, ... }
 
 // Get all songs from an album
-const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ 'Kygo, Valerie Broussard - The Truth', 'OneRepublic, Kygo - Lose Somebody', ... ]
+const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ { track: "", info: { ... } }, ... ]
 
 // Get all songs from a playlist
-const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ 'Da Baby, Roddy Rich - ROCKSTAR', 'The Weeknd - Blinding Lights', ... ]
+const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ { track: "", info: { ... } }, ... ]
 
 // Fetch song from the Lavalink API
 const track = await spotilink.fetchTrack(song) // { track: "", info: {} }
@@ -51,21 +51,6 @@ const tracks = [];
 await Promise.all(album.map(async (name) => tracks.push(await spotilink.fetchTrack(name))));
 // 'tracks' will now contain Lavalink track objects.
 // SpotifyParser#fetchTrack will only return the track object, giving you complete freedom and control on how you handle the Lavalink tracks. :)
-```
----
-
-The following methods below, if `true` is passed on the second parameter will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
-```javascript
-// Get a song in the form of a Lavalink object.
-const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
-
-// Get all songs from an album in the form of an array of Lavalink objects.
-const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ', true);
-
-// Get all songs from a playlist in the form of an array of Lavalink objects.
-const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', true);
-
-
 ```
 
 ## Contributors ✨

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ const node = {
 const spotilink =  new SpotifyParser(node, spotifyID, spotifySecret);
 
 // Get a song title
-const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // { track: "", info: { author: "Surfaces", title: "Surfaces - Sunday Best (Official Music Video)" }, ... }
+const song = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo'); // { artists: [ "Surfaces" ], name: "Sunday Best" }
 
 // Get all songs from an album
-const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ { track: "", info: { ... } }, ... ]
+const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ'); // [ { artists: [ "Kygo", "Valerie Broussard" ], name: "The Truth" }, ... ]
 
 // Get all songs from a playlist
-const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ { track: "", info: { ... } }, ... ]
+const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF') // [ { arists: [ "Cardi B", "Megan Thee Stallion" ], name: "WAP (feat. Megan Thee Stallion)" }, ... ]
 
 // Fetch song from the Lavalink API
 const track = await spotilink.fetchTrack(song) // { track: "", info: {} }
@@ -51,6 +51,19 @@ const tracks = [];
 await Promise.all(album.map(async (name) => tracks.push(await spotilink.fetchTrack(name))));
 // 'tracks' will now contain Lavalink track objects.
 // SpotifyParser#fetchTrack will only return the track object, giving you complete freedom and control on how you handle the Lavalink tracks. :)
+```
+---
+
+The following methods below, if `true` is passed on the second parameter will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
+```javascript
+// Get a song in the form of a Lavalink object.
+const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
+// Get all songs from an album in the form of an array of Lavalink objects.
+const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ', true);
+// Get all songs from a playlist in the form of an array of Lavalink objects.
+const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', true);
+
+
 ```
 
 ## Contributors ✨

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -83,6 +83,9 @@ export class SpotifyParser {
 	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
 	public async getAlbumTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+		if (!id) throw new ReferenceError("The album ID was not provided");
+		if (typeof id !== "string") throw new TypeError(`The album ID must be a string, received type ${typeof id}`);
+
 		const { songs }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
 
 		if (convert) return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
@@ -95,6 +98,9 @@ export class SpotifyParser {
 	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
 	public async getPlaylistTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+		if (!id) throw new ReferenceError("The playlist ID was not provided");
+		if (typeof id !== "string") throw new TypeError(`The playlist ID must be a string, received type ${typeof id}`);
+
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
 
 		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
@@ -107,6 +113,9 @@ export class SpotifyParser {
 	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
 	public async getTrack(id: string, convert = false): Promise<LavalinkTrack|SpotifyTrack> {
+		if (!id) throw new ReferenceError("The track ID was not provided");
+		if (typeof id !== "string") throw new TypeError(`The track ID must be a string, received type ${typeof id}`);
+
 		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 
 		if (convert) return this.fetchTrack(track) as unknown as LavalinkTrack;
@@ -118,6 +127,12 @@ export class SpotifyParser {
 	 * @param track The Spotify track object to be searched and compared against the Lavalink API
 	 */
 	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
+		if (!track) throw ReferenceError("The Spotify track object was not provided");
+		if (!track.artists) throw ReferenceError("The track artists array was not provided");
+		if (!track.name) throw ReferenceError("The track name was not provided");
+		if (!Array.isArray(track.artists)) throw TypeError(`The track artists must be an array, received type ${typeof track.artists}`);
+		if (typeof track.name !== "string") throw TypeError(`The track name must be a string, received type ${typeof track.name}`);
+
 		const title = `${track.artists.map(artist => artist.name).join(", ")} - ${track.name}`;
 
 		const params = new URLSearchParams();

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -80,7 +80,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the album and return its artists and track name.
 	 * @param id The album ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
 	public async getAlbumTracks(id: string): Promise<LavalinkTrack[]> {
 		const { songs }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
@@ -91,7 +90,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the playlist and return its artists and track name.
 	 * @param id The playlist ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
 	public async getPlaylistTracks(id: string): Promise<LavalinkTrack[]> {
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
@@ -102,7 +100,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the track and return its artist and title
 	 * @param id The song ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track name.
 	 */
 	public async getTrack(id: string): Promise<LavalinkTrack> {
 		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
@@ -112,7 +109,7 @@ export class SpotifyParser {
 
 	/**
 	 * Return a LavalinkTrack object from the track title.
-	 * @param track The track title to be taken from the Lavalink API
+	 * @param track The Spotify track object to be searched and compared against the Lavalink API
 	 */
 	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
 		const title = `${track.artists.map(artist => artist.name).join(", ")} - ${track.name}`;

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -149,15 +149,15 @@ export class SpotifyParser {
 
 		return tracks
 			// prioritize music videos first (lowest priority)
-			.sort((a) => /(official)? ?(music)? ?video/i.test(a.info.title) ? -1 : 1)
+			.sort((a) => /(official)? ?(music)? ?video/i.test(a.info.title) ? -1 : 0)
 			// prioritize lyric videos first
-			.sort((a) => /(official)? ?lyrics? ?(video)?/i.test(a.info.title) ? -1 : 1)
+			.sort((a) => /(official)? ?lyrics? ?(video)?/i.test(a.info.title) ? -1 : 0)
 			// prioritize official audios first
-			.sort((a) => /(official)? ?audio/i.test(a.info.title) ? -1 : 1)
+			.sort((a) => /(official)? ?audio/i.test(a.info.title) ? -1 : 0)
 			// prioritize channel name
-			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 1)
+			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 0)
 			// prioritize if the video title is the same as the song title (highest priority)
-			.sort((a) => new RegExp(`^${track.name}$`, "i").test(a.info.title) ? -1 : 1)[0];
+			.sort((a) => new RegExp(`^${track.name}$`, "i").test(a.info.title) ? -1 : 0)[0];
 	}
 
 	private async renewToken(): Promise<number> {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -127,11 +127,11 @@ export class SpotifyParser {
 	 * @param track The Spotify track object to be searched and compared against the Lavalink API
 	 */
 	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
-		if (!track) throw ReferenceError("The Spotify track object was not provided");
-		if (!track.artists) throw ReferenceError("The track artists array was not provided");
-		if (!track.name) throw ReferenceError("The track name was not provided");
-		if (!Array.isArray(track.artists)) throw TypeError(`The track artists must be an array, received type ${typeof track.artists}`);
-		if (typeof track.name !== "string") throw TypeError(`The track name must be a string, received type ${typeof track.name}`);
+		if (!track) throw new ReferenceError("The Spotify track object was not provided");
+		if (!track.artists) throw new ReferenceError("The track artists array was not provided");
+		if (!track.name) throw new ReferenceError("The track name was not provided");
+		if (!Array.isArray(track.artists)) throw new TypeError(`The track artists must be an array, received type ${typeof track.artists}`);
+		if (typeof track.name !== "string") throw new TypeError(`The track name must be a string, received type ${typeof track.name}`);
 
 		const title = `${track.artists.map(artist => artist.name).join(", ")} - ${track.name}`;
 

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -136,7 +136,7 @@ export class SpotifyParser {
 		const title = `${track.artists.map(artist => artist.name).join(", ")} - ${track.name}`;
 
 		const params = new URLSearchParams();
-		params.append("identifier", encodeURIComponent(`ytsearch: ${title}`));
+		params.append("identifier", `ytsearch: ${title}`);
 
 		const { host, port, password } = this.nodes;
 		const { tracks } = await (await fetch(`http://${host}:${port}/loadtracks?${params}`, {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -78,9 +78,9 @@ export class SpotifyParser {
 	}
 
 	/**
-	 * Fetch the tracks from the album and return its artists and track name.
+	 * Fetch the tracks from the album and return the SpotifyTrack or LavalinkTrack objects.
 	 * @param id The album ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
+	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
 	public async getAlbumTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The album ID was not provided");
@@ -93,9 +93,9 @@ export class SpotifyParser {
 	}
 
 	/**
-	 * Fetch the tracks from the playlist and return its artists and track name.
+	 * Fetch the tracks from the playlist and return the SpotifyTrack or LavalinkTrack objects.
 	 * @param id The playlist ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
+	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
 	public async getPlaylistTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The playlist ID was not provided");
@@ -108,9 +108,9 @@ export class SpotifyParser {
 	}
 
 	/**
-	 * Fetch the track and return its artist and title
+	 * Fetch the track and return its SpotifyTrack or LavalinkTrack object.
 	 * @param id The song ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
+	 * @param convert Whether to return results as LavalinkTracks objects instead of SpotifyTrack objects.
 	 */
 	public async getTrack(id: string, convert = false): Promise<LavalinkTrack|SpotifyTrack> {
 		if (!id) throw new ReferenceError("The track ID was not provided");
@@ -123,8 +123,8 @@ export class SpotifyParser {
 	}
 
 	/**
-	 * Return a LavalinkTrack object from the track title.
-	 * @param track The Spotify track object to be searched and compared against the Lavalink API
+	 * Return a LavalinkTrack object from the SpotifyTrack object.
+	 * @param track The SpotifyTrack object to be searched and compared against the Lavalink API
 	 */
 	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
 		if (!track) throw new ReferenceError("The Spotify track object was not provided");

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -80,40 +80,46 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the album and return its artists and track name.
 	 * @param id The album ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getAlbumTracks(id: string): Promise<LavalinkTrack[]> {
+	public async getAlbumTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The album ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The album ID must be a string, received type ${typeof id}`);
 
 		const { songs }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
 
-		return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
+		return songs;
 	}
 
 	/**
 	 * Fetch the tracks from the playlist and return its artists and track name.
 	 * @param id The playlist ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getPlaylistTracks(id: string): Promise<LavalinkTrack[]> {
+	public async getPlaylistTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The playlist ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The playlist ID must be a string, received type ${typeof id}`);
 
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
 
-		return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
+		return items.map(item => item.track);
 	}
 
 	/**
 	 * Fetch the track and return its artist and title
 	 * @param id The song ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getTrack(id: string): Promise<LavalinkTrack> {
+	public async getTrack(id: string, convert = false): Promise<LavalinkTrack|SpotifyTrack> {
 		if (!id) throw new ReferenceError("The track ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The track ID must be a string, received type ${typeof id}`);
 
 		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 
-		return this.fetchTrack(track) as unknown as LavalinkTrack;
+		if (convert) return this.fetchTrack(track) as unknown as LavalinkTrack;
+		return track;
 	}
 
 	/**

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -10,7 +10,7 @@ export interface Node {
 }
 
 export interface Album {
-	items: [Track];
+	songs: SpotifyTrack[];
 }
 
 export interface Artist {
@@ -18,8 +18,8 @@ export interface Artist {
 }
 
 export interface LavalinkTrack {
-	track?: string;
-	info?: {
+	track: string;
+	info: {
 		identifier: string;
 		isSeekable: boolean;
 		author: string;
@@ -31,13 +31,17 @@ export interface LavalinkTrack {
 	}
 }
 
+export interface LavalinkSearchResult {
+	tracks: LavalinkTrack[];
+}
+
 export interface PlaylistItems {
 	items: [{
-		track: Track;
+		track: SpotifyTrack;
 	}];
 }
 
-export interface Track {
+export interface SpotifyTrack {
 	artists: Artist[];
 	name: string;
 }
@@ -78,16 +82,10 @@ export class SpotifyParser {
 	 * @param id The album ID.
 	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
-	public async getAlbumTracks(id: string, convert = false): Promise<string[]|LavalinkTrack[]> {
-		const { items }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
-		const tracks = items.map(song => `${song.artists.map(artist => artist.name).join(", ")} - ${song.name}`);
+	public async getAlbumTracks(id: string): Promise<LavalinkTrack[]> {
+		const { songs }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
 
-		if (convert) {
-			return Promise.all(tracks.map(async (title) => await this.fetchTrack(title)) as LavalinkTrack[]);
-		}
-
-		return tracks;
-
+		return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
 	}
 
 	/**
@@ -95,15 +93,10 @@ export class SpotifyParser {
 	 * @param id The playlist ID.
 	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
-	public async getPlaylistTracks(id: string, convert = false): Promise<string[]|LavalinkTrack[]> {
+	public async getPlaylistTracks(id: string): Promise<LavalinkTrack[]> {
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
-		const tracks: string[] = items.map(item => `${item.track.artists.map(artist => artist.name).join(", ")} - ${item.track.name}`);
 
-		if (convert) {
-			return Promise.all(tracks.map(async (title) => await this.fetchTrack(title)) as LavalinkTrack[]);
-		}
-
-		return tracks;
+		return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
 	}
 
 	/**
@@ -111,33 +104,42 @@ export class SpotifyParser {
 	 * @param id The song ID.
 	 * @param convert Whether to return results as Lavalink tracks instead of track name.
 	 */
-	public async getTrack(id: string, convert = false): Promise<string|LavalinkTrack> {
-		const track: Track = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
-		const artists: string[] = track.artists.map(artist => artist.name);
-		const title = `${artists.join(", ")} - ${track.name}`;
+	public async getTrack(id: string): Promise<LavalinkTrack> {
+		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 
-		if (convert) {
-			return this.fetchTrack(title) as LavalinkTrack;
-		}
-
-		return title;
+		return this.fetchTrack(track) as unknown as LavalinkTrack;
 	}
 
 	/**
 	 * Return a LavalinkTrack object from the track title.
 	 * @param track The track title to be taken from the Lavalink API
 	 */
-	public async fetchTrack(track: string): Promise<LavalinkTrack|null> {
+	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
+		const title = `${track.artists.map(artist => artist.name).join(", ")} - ${track.name}`;
+
 		const params = new URLSearchParams();
-		params.append("identifier", `ytsearch: ${track}`);
+		params.append("identifier", encodeURIComponent(`ytsearch: ${title}`));
+
 		const { host, port, password } = this.nodes;
-		const { tracks } = (await (await fetch(`http://${host}:${port}/loadtracks?${params}`, {
+		const { tracks } = await (await fetch(`http://${host}:${port}/loadtracks?${params}`, {
 			headers: {
 				Authorization: password
 			}
-		})).json());
+		})).json() as LavalinkSearchResult;
+
 		if (!tracks.length) return null;
-		return tracks[0];
+
+		return tracks
+			// prioritize music videos first (lowest priority)
+			.sort((a) => /(official)? ?(music)? ?video/i.test(a.info.title) ? -1 : 1)
+			// prioritize lyric videos first
+			.sort((a) => /(official)? ?lyrics? ?(video)?/i.test(a.info.title) ? -1 : 1)
+			// prioritize official audios first
+			.sort((a) => /(official)? ?audio/i.test(a.info.title) ? -1 : 1)
+			// prioritize channel name
+			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 1)
+			// prioritize if the video title is the same as the song title (highest priority)
+			.sort((a) => new RegExp(`^${track.name}$`, "i").test(a.info.title) ? -1 : 1)[0];
 	}
 
 	private async renewToken(): Promise<number> {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -80,7 +80,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the album and return its artists and track name.
 	 * @param id The album ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
 	public async getAlbumTracks(id: string): Promise<LavalinkTrack[]> {
 		if (!id) throw new ReferenceError("The album ID was not provided");
@@ -94,7 +93,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the playlist and return its artists and track name.
 	 * @param id The playlist ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track names.
 	 */
 	public async getPlaylistTracks(id: string): Promise<LavalinkTrack[]> {
 		if (!id) throw new ReferenceError("The playlist ID was not provided");
@@ -108,7 +106,6 @@ export class SpotifyParser {
 	/**
 	 * Fetch the track and return its artist and title
 	 * @param id The song ID.
-	 * @param convert Whether to return results as Lavalink tracks instead of track name.
 	 */
 	public async getTrack(id: string): Promise<LavalinkTrack> {
 		if (!id) throw new ReferenceError("The track ID was not provided");
@@ -121,7 +118,7 @@ export class SpotifyParser {
 
 	/**
 	 * Return a LavalinkTrack object from the track title.
-	 * @param track The track title to be taken from the Lavalink API
+	 * @param track The Spotify track object to be searched and compared against the Lavalink API
 	 */
 	public async fetchTrack(track: SpotifyTrack): Promise<LavalinkTrack|null> {
 		if (!track) throw ReferenceError("The Spotify track object was not provided");

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -147,10 +147,10 @@ export class SpotifyParser {
 
 		if (!tracks.length) return null;
 
-		return tracks
-			// prioritize channel name (lowest priority)
-			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 0)
-			// prioritize music videos first
+		const filteredTracks = tracks.filter(searchResult => [track.artists[0].name, `${track.artists[0].name} - Topic`].some(channelName => new RegExp(`^${channelName}$`, "i").test(searchResult.info.author)));
+
+		return (filteredTracks.length ? filteredTracks : tracks)
+			// prioritize music videos first (lowest priority)
 			.sort((a) => /(official)? ?(music)? ?video/i.test(a.info.title) ? -1 : 0)
 			// prioritize lyric videos first
 			.sort((a) => /(official)? ?lyrics? ?(video)?/i.test(a.info.title) ? -1 : 0)

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -80,31 +80,37 @@ export class SpotifyParser {
 	/**
 	 * Fetch the tracks from the album and return its artists and track name.
 	 * @param id The album ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getAlbumTracks(id: string): Promise<LavalinkTrack[]> {
+	public async getAlbumTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		const { songs }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
 
-		return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(songs.map(async (song) => await this.fetchTrack(song)) as unknown as LavalinkTrack[]);
+		return songs;
 	}
 
 	/**
 	 * Fetch the tracks from the playlist and return its artists and track name.
 	 * @param id The playlist ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getPlaylistTracks(id: string): Promise<LavalinkTrack[]> {
+	public async getPlaylistTracks(id: string, convert = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
 
-		return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item.track)) as unknown as LavalinkTrack[]);
+		return items.map(item => item.track);
 	}
 
 	/**
 	 * Fetch the track and return its artist and title
 	 * @param id The song ID.
+	 * @param convert Whether to return results as Lavalink tracks instead of Spotify track object.
 	 */
-	public async getTrack(id: string): Promise<LavalinkTrack> {
+	public async getTrack(id: string, convert = false): Promise<LavalinkTrack|SpotifyTrack> {
 		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 
-		return this.fetchTrack(track) as unknown as LavalinkTrack;
+		if (convert) return this.fetchTrack(track) as unknown as LavalinkTrack;
+		return track;
 	}
 
 	/**

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -148,14 +148,14 @@ export class SpotifyParser {
 		if (!tracks.length) return null;
 
 		return tracks
-			// prioritize music videos first (lowest priority)
+			// prioritize channel name (lowest priority)
+			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 0)
+			// prioritize music videos first
 			.sort((a) => /(official)? ?(music)? ?video/i.test(a.info.title) ? -1 : 0)
 			// prioritize lyric videos first
 			.sort((a) => /(official)? ?lyrics? ?(video)?/i.test(a.info.title) ? -1 : 0)
 			// prioritize official audios first
 			.sort((a) => /(official)? ?audio/i.test(a.info.title) ? -1 : 0)
-			// prioritize channel name
-			.sort((a) => [track.artists[0].name, `${track.artists[0].name} - Topic`].includes(a.info.author) ? -1 : 0)
 			// prioritize if the video title is the same as the song title (highest priority)
 			.sort((a) => new RegExp(`^${track.name}$`, "i").test(a.info.title) ? -1 : 0)[0];
 	}


### PR DESCRIPTION
## Description
This pull request makes sure that the track returned from the three methods is an official upload from the artist. The PR also changes how the four methods, `getTrack`, `getAlbumTracks`, `getPlaylistTracks`, and `fetchTrack`, work - the first three mentioned now return a Spotify track object instead of the track title, and `fetchTrack` now requires a Spotify track object instead of track title.

## Motivation and Context
The tracks from search results are sorted through various checks to make sure that the tracks are official uploads.

## How Has This Been Tested?
This pull request has been tested on a local machine using Node.js's built-in editor. The PR has been tested to work on Node.js version 14.5.0.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
