### PR TITLE
release 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', tru
 
 You can use custom functions to manipulate the search results.
 For the three main methods used, you can pass an object containing the functions for filtering and sorting.
-By default, no filtering and sorting takes place. This means that whichever the first track that Lavalink may have received will be returned.
+By default, no filtering and sorting takes place — whichever track that Lavalink may have received first will be returned.
 ```javascript
 // Prioritize Lavalink tracks with the same duration as the Spotify track.
 spotilink.getTrack('track ID', , { prioritizeSameDuration: true });
@@ -79,7 +79,8 @@ spotilink.getAlbumTracks('album ID', , { customFilter: (lavalinkTrack, spotifyTr
 
 // Use a custom synchronous function for sorting search results
 // The synchronous function being passed must return a number type variable
-spotilink.getPlaylistTracks('playlist ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1 })
+// Variables `comparableTrack` and `compareToTrack` are of LavalinkTrack types
+spotilink.getPlaylistTracks('playlist ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => comparableTrack.info.title === spotifyTrack.name ? -1 : 1 })
 ```
 Please note that if you use the option `prioritizeSameDuration`, the other options mentioned will be unused. The options `customFilter` and `customSort` however, may be used together as long as `prioritizeSameDuration` is set to `false`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ await Promise.all(album.map(async (name) => tracks.push(await spotilink.fetchTra
 ```
 ---
 
-The following methods below, if `true` is passed on the second parameter will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
+The following methods below, if `true` is passed as the second parameter, will call `Spotilink#fetchTrack` and return a Lavalink object (an array of them for getAlbumTracks and getPlaylistTracks) instead of song titles and artists.
 ```javascript
 // Get a song in the form of a Lavalink object.
 const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
@@ -63,9 +63,25 @@ const lavalinkSong = await spotilink.getTrack('1Cv1YLb4q0RzL6pybtaMLo', true);
 const album = await spotilink.getAlbumTracks('7tcs1X9pzFvcLOPuhCstQJ', true);
 // Get all songs from a playlist in the form of an array of Lavalink objects.
 const playlist = await spotilink.getPlaylistTracks('37i9dQZEVXbMDoHDwVN2tF', true);
-
-
 ```
+---
+
+You can use custom functions to manipulate the search results.
+For the three main methods used, you can pass an object containing the functions for filtering and sorting.
+By default, no filtering and sorting takes place. This means that whichever the first track that Lavalink may have received will be returned.
+```javascript
+// Prioritize Lavalink tracks with the same duration as the Spotify track.
+spotilink.getTrack('track ID', , { prioritizeSameDuration: true });
+
+// Use a custom synchronous function for filtering search results
+// The synchronous function being passed must return a boolean type variable
+spotilink.getTrack('track ID', , { customFilter: (lavalinkTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name })
+
+// Use a custom synchronous function for sorting search results
+// The symchronous function being passed must return a number type variable
+spotilink.getTrack('track ID', , { customSort: (comparableTrack, compareToTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1})
+```
+Please note that if you use the option `prioritizeSameDuration`, the other options mentioned will be unused. The options `customFilter` and `customSort` however, may be used together as long as `prioritizeSameDuration` is set to `false`.
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spotilink.getTrack('track ID', , { customFilter: (lavalinkTrack, spotifyTrack) =
 
 // Use a custom synchronous function for sorting search results
 // The symchronous function being passed must return a number type variable
-spotilink.getTrack('track ID', , { customSort: (comparableTrack, compareToTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1})
+spotilink.getTrack('track ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1 })
 ```
 Please note that if you use the option `prioritizeSameDuration`, the other options mentioned will be unused. The options `customFilter` and `customSort` however, may be used together as long as `prioritizeSameDuration` is set to `false`.
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ spotilink.getTrack('track ID', , { prioritizeSameDuration: true });
 
 // Use a custom synchronous function for filtering search results
 // The synchronous function being passed must return a boolean type variable
-spotilink.getTrack('track ID', , { customFilter: (lavalinkTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name })
+spotilink.getAlbumTracks('album ID', , { customFilter: (lavalinkTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name })
 
 // Use a custom synchronous function for sorting search results
 // The symchronous function being passed must return a number type variable
-spotilink.getTrack('track ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1 })
+spotilink.getPlaylistTracks('playlist ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1 })
 ```
 Please note that if you use the option `prioritizeSameDuration`, the other options mentioned will be unused. The options `customFilter` and `customSort` however, may be used together as long as `prioritizeSameDuration` is set to `false`.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ spotilink.getTrack('track ID', , { prioritizeSameDuration: true });
 spotilink.getAlbumTracks('album ID', , { customFilter: (lavalinkTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name })
 
 // Use a custom synchronous function for sorting search results
-// The symchronous function being passed must return a number type variable
+// The synchronous function being passed must return a number type variable
 spotilink.getPlaylistTracks('playlist ID', , { customSort: (comparableTrack, compareToTrack, spotifyTrack) => lavalinkTrack.info.title === spotifyTrack.name ? -1 : 1 })
 ```
 Please note that if you use the option `prioritizeSameDuration`, the other options mentioned will be unused. The options `customFilter` and `customSort` however, may be used together as long as `prioritizeSameDuration` is set to `false`.

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -50,7 +50,7 @@ export interface SpotifyTrack {
 export interface FetchOptions {
 	prioritizeSameDuration: boolean;
 	customFilter(lavalinkTrack: LavalinkTrack, spotifyTrack: SpotifyTrack): boolean;
-	customSort(comparableTrack: LavalinkTrack, compareToTrack: LavalinkTrack): number;
+	customSort(comparableTrack: LavalinkTrack, compareToTrack: LavalinkTrack, spotifyTrack: SpotifyTrack): number;
 }
 
 
@@ -160,7 +160,7 @@ export class SpotifyParser {
 
 		return tracks
 			.filter(searchResult => fetchOptions.customFilter(searchResult, track))
-			.sort((comparableTrack, compareToTrack) => fetchOptions.customSort(comparableTrack, compareToTrack))[0];
+			.sort((comparableTrack, compareToTrack) => fetchOptions.customSort(comparableTrack, compareToTrack, track))[0];
 	}
 
 	private async renewToken(): Promise<number> {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -85,7 +85,7 @@ export class SpotifyParser {
 	 * @param id The album ID.
 	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
-	public async getAlbumTracks(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+	public async getAlbumTracks(id: string, convert = false, fetchOptions: FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The album ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The album ID must be a string, received type ${typeof id}`);
 
@@ -100,7 +100,7 @@ export class SpotifyParser {
 	 * @param id The playlist ID.
 	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
-	public async getPlaylistTracks(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+	public async getPlaylistTracks(id: string, convert = false, fetchOptions: FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The playlist ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The playlist ID must be a string, received type ${typeof id}`);
 
@@ -115,7 +115,7 @@ export class SpotifyParser {
 	 * @param id The song ID.
 	 * @param convert Whether to return results as LavalinkTracks objects instead of SpotifyTrack objects.
 	 */
-	public async getTrack(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack|SpotifyTrack> {
+	public async getTrack(id: string, convert = false, fetchOptions: FetchOptions): Promise<LavalinkTrack|SpotifyTrack> {
 		if (!id) throw new ReferenceError("The track ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The track ID must be a string, received type ${typeof id}`);
 

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -56,8 +56,6 @@ export interface FetchOptions {
 
 export class SpotifyParser {
 	public nodes: Node;
-	public id: string;
-	private secret: string;
 	private authorization: string;
 	private token: string;
 	private options: { headers: { "Content-Type": string; Authorization: string; }; };
@@ -70,8 +68,6 @@ export class SpotifyParser {
 	 */
 	constructor(LavalinkNode: Node, clientID: string, clientSecret: string) {
 		this.nodes = LavalinkNode;
-		this.id = clientID;
-		this.secret = clientSecret;
 		this.authorization = Buffer.from(`${clientID}:${clientSecret}`).toString("base64");
 		this.token = "";
 		this.options = {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -49,6 +49,7 @@ export interface SpotifyTrack {
 
 export interface FetchOptions {
 	prioritizeSameDuration: boolean;
+	customFilter(lavalinkTrack: LavalinkTrack, spotifyTrack: SpotifyTrack): boolean;
 }
 
 
@@ -131,7 +132,7 @@ export class SpotifyParser {
 	 * Return a LavalinkTrack object from the SpotifyTrack object.
 	 * @param track The SpotifyTrack object to be searched and compared against the Lavalink API
 	 */
-	public async fetchTrack(track: SpotifyTrack, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack|null> {
+	public async fetchTrack(track: SpotifyTrack, fetchOptions = { prioritizeSameDuration: false, customFilter: () => true } as FetchOptions): Promise<LavalinkTrack|null> {
 		if (!track) throw new ReferenceError("The Spotify track object was not provided");
 		if (!track.artists) throw new ReferenceError("The track artists array was not provided");
 		if (!track.name) throw new ReferenceError("The track name was not provided");
@@ -157,7 +158,7 @@ export class SpotifyParser {
 			if (sameDuration) return sameDuration;
 		}
 
-		return tracks[0];
+		return tracks.filter(async searchResult => fetchOptions.customFilter(searchResult, track))[0];
 	}
 
 	private async renewToken(): Promise<number> {

--- a/src/lib/SpotifyParser.ts
+++ b/src/lib/SpotifyParser.ts
@@ -87,13 +87,13 @@ export class SpotifyParser {
 	 * @param id The album ID.
 	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
-	public async getAlbumTracks(id: string, convert = false, prioritizeSameDuration = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+	public async getAlbumTracks(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The album ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The album ID must be a string, received type ${typeof id}`);
 
 		const { items }: Album = (await (await fetch(`${BASE_URL}/albums/${id}/tracks`, this.options)).json());
 
-		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item, { prioritizeSameDuration })) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item, fetchOptions)) as unknown as LavalinkTrack[]);
 		return items;
 	}
 
@@ -102,13 +102,13 @@ export class SpotifyParser {
 	 * @param id The playlist ID.
 	 * @param convert Whether to return results as LavalinkTrack objects instead of SpotifyTrack objects.
 	 */
-	public async getPlaylistTracks(id: string, convert = false, prioritizeSameDuration = false): Promise<LavalinkTrack[]|SpotifyTrack[]> {
+	public async getPlaylistTracks(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack[]|SpotifyTrack[]> {
 		if (!id) throw new ReferenceError("The playlist ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The playlist ID must be a string, received type ${typeof id}`);
 
 		const { items }: PlaylistItems = (await (await fetch(`${BASE_URL}/playlists/${id}/tracks`, this.options)).json());
 
-		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item.track, { prioritizeSameDuration })) as unknown as LavalinkTrack[]);
+		if (convert) return Promise.all(items.map(async (item) => await this.fetchTrack(item.track, fetchOptions)) as unknown as LavalinkTrack[]);
 		return items.map(item => item.track);
 	}
 
@@ -117,13 +117,13 @@ export class SpotifyParser {
 	 * @param id The song ID.
 	 * @param convert Whether to return results as LavalinkTracks objects instead of SpotifyTrack objects.
 	 */
-	public async getTrack(id: string, convert = false, prioritizeSameDuration = false): Promise<LavalinkTrack|SpotifyTrack> {
+	public async getTrack(id: string, convert = false, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack|SpotifyTrack> {
 		if (!id) throw new ReferenceError("The track ID was not provided");
 		if (typeof id !== "string") throw new TypeError(`The track ID must be a string, received type ${typeof id}`);
 
 		const track: SpotifyTrack = (await (await fetch(`${BASE_URL}/tracks/${id}`, this.options)).json());
 
-		if (convert) return this.fetchTrack(track, { prioritizeSameDuration }) as unknown as LavalinkTrack;
+		if (convert) return this.fetchTrack(track, fetchOptions) as unknown as LavalinkTrack;
 		return track;
 	}
 
@@ -131,7 +131,7 @@ export class SpotifyParser {
 	 * Return a LavalinkTrack object from the SpotifyTrack object.
 	 * @param track The SpotifyTrack object to be searched and compared against the Lavalink API
 	 */
-	public async fetchTrack(track: SpotifyTrack, { prioritizeSameDuration = false } = {} as FetchOptions): Promise<LavalinkTrack|null> {
+	public async fetchTrack(track: SpotifyTrack, fetchOptions = { prioritizeSameDuration: false } as FetchOptions): Promise<LavalinkTrack|null> {
 		if (!track) throw new ReferenceError("The Spotify track object was not provided");
 		if (!track.artists) throw new ReferenceError("The track artists array was not provided");
 		if (!track.name) throw new ReferenceError("The track name was not provided");
@@ -152,7 +152,7 @@ export class SpotifyParser {
 
 		if (!tracks.length) return null;
 
-		if (prioritizeSameDuration) {
+		if (fetchOptions.prioritizeSameDuration) {
 			const sameDuration = tracks.filter(searchResult => (searchResult.info.length >= (track.duration_ms - 1500)) && (searchResult.info.length <= (track.duration_ms + 1500)))[0];
 			if (sameDuration) return sameDuration;
 		}


### PR DESCRIPTION
## Description
This pull request will implement track-fetching filtering as optional, as well as allowing developers to create their own filtering and sorting methods.

## Motivation and Context
The package must be customizable and the developers should be able to freely control results from converting Spotify tracks to YouTube tracks via Lavalink.

## How Has This Been Tested?
This pull request has not yet been tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
